### PR TITLE
Add Codex compatibility docs and skill wrappers

### DIFF
--- a/.agents/skills/bmad-bmm-issue-sync/SKILL.md
+++ b/.agents/skills/bmad-bmm-issue-sync/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: bmad-bmm-issue-sync
+description: 'Sync sprint-status.yaml entries to GitLab/GitHub Issues from Codex. Use when the user says "sync issues" or wants to push sprint status to the issue tracker.'
+---
+
+# Sync Sprint Status to Issues
+
+This is the Codex discovery wrapper for the canonical BMAD skill.
+
+When invoked:
+
+1. Open and follow `../../../skills/bmad-bmm-issue-sync/SKILL.md`.
+2. Treat that canonical file as the source of truth.
+3. Do not run task logic from this wrapper if the canonical file differs.

--- a/.agents/skills/bmad-issue-tracking-setup/SKILL.md
+++ b/.agents/skills/bmad-issue-tracking-setup/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: bmad-issue-tracking-setup
+description: 'Set up BMAD Issue Tracking from Codex. Use after installing the module to deploy TOML overrides, shared tasks, and issue-tracking configuration.'
+---
+
+# Issue Tracking Setup
+
+This is the Codex discovery wrapper for the canonical BMAD setup skill.
+
+When invoked:
+
+1. Open and follow `../../../skills/bmad-issue-tracking-setup/SKILL.md`.
+2. Treat that canonical file as the source of truth.
+3. Do not run task logic from this wrapper if the canonical file differs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,28 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex when working with code in this repository.
 
 ## What this is
 
-BMAD extension module that integrates sprint tracking with GitLab/GitHub Issues. It's not a runnable application — it's a set of TOML overrides and skills deployed into consuming BMAD projects via the BMAD installer (`npx bmad-method install`).
+BMAD extension module that integrates sprint tracking with GitLab/GitHub Issues. It is not a runnable application. It is a set of TOML overrides and skills deployed into consuming BMAD projects via the BMAD installer (`npx bmad-method install`).
 
 Requires BMM 6.4.0+ (uniform customize.toml support across all BMM workflows).
+
+## Codex compatibility
+
+Codex discovers repository skills from `.agents/skills`. Keep those files as thin wrappers that point to the canonical BMAD skill sources under `skills/`.
+
+Canonical sources:
+
+- `skills/bmad-bmm-issue-sync/SKILL.md`
+- `skills/bmad-issue-tracking-setup/SKILL.md`
+
+Codex wrappers:
+
+- `.agents/skills/bmad-bmm-issue-sync/SKILL.md`
+- `.agents/skills/bmad-issue-tracking-setup/SKILL.md`
+
+Do not duplicate task logic in `.agents/skills`. Update the canonical `skills/` files first, then update wrapper descriptions only if trigger behavior changes.
 
 ## Architecture
 
@@ -15,17 +31,12 @@ Two concepts that must stay aligned:
 - **Standalone skill** (`skills/bmad-bmm-issue-sync/SKILL.md`) — the user-facing slash command (`/bmad-bmm-issue-sync`) and the single source of truth for the sync task
 - **Deployed copy** — during setup, this file is copied to `_bmad/_config/custom/bmad-bmm-issue-sync.md` in the consuming project. TOML `on_complete` hooks reference this deployed path.
 
-The standalone skill IS the source. If you edit it, the deployed copy in consuming projects won't update automatically — users must re-run `/bmad-issue-tracking-setup`.
-
-## Codex compatibility
-
-Codex reads repository guidance from `AGENTS.md` and discovers repo-scoped skills from `.agents/skills`. The `.agents/skills` files are thin wrappers that point to the canonical BMAD skill sources under `skills/`.
-
-Do not duplicate task logic in `.agents/skills`. Update the canonical `skills/` files first, then update wrapper descriptions only if trigger behavior changes.
+The standalone skill is the source. If you edit it, the deployed copy in consuming projects will not update automatically. Users must re-run `/bmad-issue-tracking-setup`.
 
 ## TOML override semantics
 
 Files in `skills/bmad-issue-tracking-setup/assets/custom/` are TOML overrides for BMM workflows:
+
 - `[workflow] activation_steps_append` — array, appends to BMM's activation steps
 - `[workflow] on_complete` — scalar, replaces BMM's completion block entirely
 
@@ -33,7 +44,8 @@ All overrides use the same config guard pattern: check `issue_tracking.platform`
 
 ## Key variable conventions in instructions
 
-TOML instructions reference these placeholders — they are NOT config variables, they're resolved at runtime by the AI agent:
+TOML instructions reference these placeholders. They are not config variables; they are resolved at runtime by the AI agent:
+
 - `{prd_key}` — from PRD frontmatter, e.g. `mobile-oidc`
 - `{story_key}` — sprint-status entry key, e.g. `1-3-login-form`
 - `{epic_num}`, `{story_num}` — extracted from `story_key` (first two dash-separated numbers)
@@ -45,14 +57,14 @@ TOML instructions reference these placeholders — they are NOT config variables
 
 ## Branch/MR flow
 
-Branch setup happens in activation (before BMM workflow runs). The BMM workflow creates files directly in the worktree. on_complete handles commit/push/issue/MR. Never commit on PRD for story work.
+Branch setup happens in activation before BMM workflow output is written. The BMM workflow creates files directly in the worktree. `on_complete` handles commit, push, issue, and MR/PR work. Never commit on the PRD branch for story work.
 
 | Workflow | Activation | on_complete | MR direction |
-|----------|-----------|-------------|--------------|
-| create-prd | Create/switch to PRD worktree | Commit + push + issue + draft MR | PRD → default (draft) |
-| create-story | Ask story key, create/switch to story worktree (from PRD) | Commit + push + issue + MR | story → PRD |
+|----------|------------|-------------|--------------|
+| create-prd | Create/switch to PRD worktree | Commit + push + issue + draft MR | PRD -> default (draft) |
+| create-story | Ask story key, create/switch to story worktree (from PRD) | Commit + push + issue + MR | story -> PRD |
 | dev-story | Find story with status `ready-for-dev`, switch to worktree | Commit + push + update issue | (MR from create-story) |
-| code-review | Find story with status `review`, switch to worktree | Commit + push + post review + optional merge | story → PRD |
+| code-review | Find story with status `review`, switch to worktree | Commit + push + post review + optional merge | story -> PRD |
 
 ## Platform differences
 
@@ -64,17 +76,17 @@ Branch setup happens in activation (before BMM workflow runs). The BMM workflow 
 
 ## Files to update when adding a new BMM workflow override
 
-1. Create `skills/bmad-issue-tracking-setup/assets/custom/bmad-{workflow}.toml` with the config guard
-2. Add it to the file list in `skills/bmad-issue-tracking-setup/SKILL.md` (step 3)
-3. Add a row to the override table in `README.md`
-4. Update `module-help.csv` if the workflow has a standalone skill
+1. Create `skills/bmad-issue-tracking-setup/assets/custom/bmad-{workflow}.toml` with the config guard.
+2. Add it to the file list in `skills/bmad-issue-tracking-setup/SKILL.md` (step 3).
+3. Add a row to the override table in `README.md`.
+4. Update `module-help.csv` if the workflow has a standalone skill.
 
 ## Files to update when adding a new standalone skill
 
-1. Create the canonical skill under `skills/{skill-name}/SKILL.md`
-2. Add a Codex wrapper under `.agents/skills/{skill-name}/SKILL.md`
-3. Add the skill to `module-help.csv`
-4. Document the command in `README.md`
+1. Create the canonical skill under `skills/{skill-name}/SKILL.md`.
+2. Add a Codex wrapper under `.agents/skills/{skill-name}/SKILL.md`.
+3. Add the skill to `module-help.csv`.
+4. Document the command in `README.md`.
 
 ## Version alignment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Codex compatibility via `AGENTS.md` and `.agents/skills` discovery wrappers for the existing BMAD skills
+- README documentation for Claude Code vs Codex repository guidance and skill discovery
+
 ## [1.3.0] - 2026-04-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ BMAD extension module that mirrors sprint tracking to GitLab Issues or GitHub Is
 
 Uses BMAD's native TOML customization for all workflow integrations.
 
+Compatible with Claude Code and Codex:
+
+- Claude Code reads repository guidance from `CLAUDE.md`.
+- Codex reads repository guidance from `AGENTS.md`.
+- Codex discovers repo-scoped skill wrappers from `.agents/skills`, which delegate to the canonical BMAD skills under `skills/`.
+
 ## Prerequisites
 
 - BMAD Method module (BMM) 6.4.0+ installed in your project
@@ -51,6 +57,17 @@ Registered as slash commands in your IDE.
 |---|---|---|
 | Sync Issues | `/bmad-bmm-issue-sync` | Sync `sprint-status.yaml` to issues, mark draft PR ready |
 | Setup | `/bmad-issue-tracking-setup` | One-time integration setup |
+
+### Codex skills
+
+Codex can also discover the same workflows directly from the repository:
+
+| Skill | Codex location | Source of truth |
+|---|---|---|
+| `bmad-bmm-issue-sync` | `.agents/skills/bmad-bmm-issue-sync/SKILL.md` | `skills/bmad-bmm-issue-sync/SKILL.md` |
+| `bmad-issue-tracking-setup` | `.agents/skills/bmad-issue-tracking-setup/SKILL.md` | `skills/bmad-issue-tracking-setup/SKILL.md` |
+
+The `.agents/skills` files are thin discovery wrappers only. Keep workflow logic in `skills/` so BMAD installer behavior stays unchanged.
 
 ### TOML overrides (via setup)
 


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` so Codex has native repository guidance alongside `CLAUDE.md`.
- Add repo-scoped Codex skill wrappers under `.agents/skills` for the existing BMAD setup and issue-sync skills.
- Document Claude Code vs Codex guidance and skill discovery in README/CHANGELOG, while keeping `skills/` as the canonical source of truth.

## Testing

- `git diff --check`
- Structural JS check for wrapper frontmatter, canonical target paths, and docs references
- `codex debug prompt-input` confirmed `AGENTS.md` loads as project documentation and both `.agents/skills` entries appear in Codex's available skill list

## OpenAI Docs References

- Codex persistent repo instructions: https://developers.openai.com/codex/cli/slash-commands#generate-agentsmd-with-init
- Codex repository skill discovery: https://developers.openai.com/codex/skills#where-to-save-skills