### PR TITLE
fix: ci-wait/story-track resolve platform from module config (self-hosted GitLab)

### DIFF
--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
@@ -42,6 +42,16 @@ fail() { echo "[ci-wait] FAIL: $*"; exit 1; }
 
 [ -n "$branch" ] || fail "not on a git branch (cwd=$worktree)"
 
+# Resolve platform from the module config first — self-hosted instances
+# (opensource.unicc.org, GHE, ...) don't betray their platform in the hostname,
+# but the module records it as `git_platform` (or `platform`) in
+# `_bmad/custom/issue-tracking.yaml`, which bmad-loop copies into each worktree.
+cfg="$worktree/_bmad/custom/issue-tracking.yaml"
+if [ -z "$platform" ] && [ -f "$cfg" ]; then
+  platform="$(sed -n 's/^\s*git_platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
+  [ -z "$platform" ] && platform="$(sed -n 's/^\s*platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
+fi
+
 # Resolve host/project/platform from the git remote when not configured.
 if [ -z "$host" ] || [ -z "$project" ] || [ -z "$platform" ]; then
   remote="$(git -C "$worktree" remote get-url origin 2>/dev/null || true)"

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -26,10 +26,12 @@ Do this after the push + MR. If any step here fails, **report it and continue â€
 do not fail the session over tracking**. The post-run `/bmad-bmm-issue-sync`
 reconciles the full board.
 
-1. Read `_bmad/custom/issue-tracking.yaml` for `platform`, `host`, `project`
-   (issue tracker). Read `prd_key` from the PRD frontmatter: find `prd.md` under
-   the planning artifacts (path from `_bmad/bmm/config.yaml` `planning_artifacts`,
-   or search the repo for `prd.md`) and read its `prd_key` frontmatter.
+1. Read `_bmad/custom/issue-tracking.yaml` for `git_platform` (git remote
+   platform â€” `gitlab` or `github`; self-hosted GitLab instances have a custom
+   host but `git_platform: gitlab`), `host`, `project`. Read `prd_key` from the
+   PRD frontmatter: find `prd.md` under the planning artifacts (path from
+   `_bmad/bmm/config.yaml` `planning_artifacts`, or search the repo for
+   `prd.md`) and read its `prd_key` frontmatter.
 
 2. Find the story's issue by its sprint key `{story_key}`, scoped by the prd label:
    - GitLab: `glab api "projects/{project}/issues?search={story_key}&labels=prd::{prd_key}" --hostname {host}`


### PR DESCRIPTION
Live-test fix: ci-wait failed on self-hosted GitLab (opensource.unicc.org) because the hostname doesn't betray the platform. Read git_platform (fallback platform) from _bmad/custom/issue-tracking.yaml — copied into worktrees by bmad-loop — before the hostname-inference fallback.