### PR TITLE
fix: ci-wait env-fault rc on config errors (no futile repair budget burn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `ci-wait.sh` (bmad-loop CI gate): configuration/environment errors now exit **126** (bmad-loop's env-fault class → the run escalates/pauses, budget resets) instead of 1 (fixable → futile repair burn → story defer). A red/timeout CI still exits 1 → `_fix_phase`.
+- `ci-wait.sh`: platform resolved from `_bmad/custom/issue-tracking.yaml` (`git_platform`) so self-hosted GitLab/GitHub instances work; inline YAML comments stripped; glab/gh API or auth failures escalate instead of silently passing as "no pipeline".
+- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`.
+
 ## [2.3.0] - 2026-08-11
 
 [compare v2.2.0...v2.3.0](https://github.com/jrevillard/bmad-issue-tracking/compare/v2.2.0...v2.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ci-wait.sh` (bmad-loop CI gate): configuration/environment errors now exit **126** (bmad-loop's env-fault class → the run escalates/pauses, budget resets) instead of 1 (fixable → futile repair burn → story defer). A red/timeout CI still exits 1 → `_fix_phase`.
 - `ci-wait.sh`: platform resolved from `_bmad/custom/issue-tracking.yaml` (`git_platform`) so self-hosted GitLab/GitHub instances work; inline YAML comments stripped; glab/gh API or auth failures escalate instead of silently passing as "no pipeline".
-- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`.
+- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`, and its title follows the module's convention `Story {epic}.{story}: {title}` instead of `CI: {branch}`.
 
 ## [2.3.0] - 2026-08-11
 

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
@@ -42,6 +42,16 @@ fail() { echo "[ci-wait] FAIL: $*"; exit 1; }
 
 [ -n "$branch" ] || fail "not on a git branch (cwd=$worktree)"
 
+# Resolve platform from the module config first — self-hosted instances
+# (opensource.unicc.org, GHE, ...) don't betray their platform in the hostname,
+# but the module records it as `git_platform` (or `platform`) in
+# `_bmad/custom/issue-tracking.yaml`, which bmad-loop copies into each worktree.
+cfg="$worktree/_bmad/custom/issue-tracking.yaml"
+if [ -z "$platform" ] && [ -f "$cfg" ]; then
+  platform="$(sed -n 's/^\s*git_platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
+  [ -z "$platform" ] && platform="$(sed -n 's/^\s*platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
+fi
+
 # Resolve host/project/platform from the git remote when not configured.
 if [ -z "$host" ] || [ -z "$project" ] || [ -z "$platform" ]; then
   remote="$(git -C "$worktree" remote get-url origin 2>/dev/null || true)"

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
@@ -36,11 +36,16 @@ project="${BMAD_LOOP_SETTING_PROJECT:-}"
 timeout_sec="${BMAD_LOOP_SETTING_TIMEOUT_SEC:-1500}"
 
 log() { echo "[ci-wait] $*"; }
+# The gate itself: red/timeout CI. bmad-loop classifies rc=1 as fixable -> _fix_phase.
 fail() { echo "[ci-wait] FAIL: $*"; exit 1; }
+# Configuration/environment errors (not the story's fault): rc=126 is bmad-loop's
+# env-fault class -> the run ESCALATES (pauses for an environment fix, budget
+# resets) instead of burning the story's repair budget on a futile repair.
+env_fail() { echo "[ci-wait] ENV-FAULT: $*"; exit 126; }
 
 # ------------------------------------------------------------------ settings
 
-[ -n "$branch" ] || fail "not on a git branch (cwd=$worktree)"
+[ -n "$branch" ] || env_fail "not on a git branch (cwd=$worktree)"
 
 # Resolve platform from the module config first — self-hosted instances
 # (opensource.unicc.org, GHE, ...) don't betray their platform in the hostname,
@@ -55,7 +60,7 @@ fi
 # Resolve host/project/platform from the git remote when not configured.
 if [ -z "$host" ] || [ -z "$project" ] || [ -z "$platform" ]; then
   remote="$(git -C "$worktree" remote get-url origin 2>/dev/null || true)"
-  [ -n "$remote" ] || fail "no origin remote and host/project not configured"
+  [ -n "$remote" ] || env_fail "no origin remote and host/project not configured"
   case "$remote" in
     git@*)
       rhost="${remote#git@}"; rhost="${rhost%%:*}"
@@ -71,19 +76,28 @@ if [ -z "$host" ] || [ -z "$project" ] || [ -z "$platform" ]; then
       rproj="$(printf '%s' "$remote" | sed -E 's#^https?://[^/]+/(.*)$#\1#')"
       rproj="${rproj%.git}"
       ;;
-    *) fail "unparseable origin remote: $remote" ;;
+    *) env_fail "unparseable origin remote: $remote" ;;
   esac
-  [ -n "$rhost" ] || fail "could not resolve host from remote"
+  [ -n "$rhost" ] || env_fail "could not resolve host from remote"
   [ -z "$host" ] && host="$rhost"
   [ -z "$project" ] && project="$rproj"
   [ -z "$platform" ] && case "$host" in
     *gitlab*) platform="gitlab" ;;
     *github*) platform="github" ;;
-    *) fail "could not infer platform from host ($host) — set BMAD_LOOP_SETTING_PLATFORM" ;;
+    *) env_fail "could not infer platform from host ($host) — set git_platform in _bmad/custom/issue-tracking.yaml or BMAD_LOOP_SETTING_PLATFORM" ;;
   esac
 fi
-[ -n "$project" ] || fail "could not resolve project from remote"
-[ -n "$platform" ] || fail "platform not resolved (gitlab | github)"
+[ -n "$project" ] || env_fail "could not resolve project from remote"
+[ -n "$platform" ] || env_fail "platform not resolved (gitlab | github)"
+
+# The CI CLI must exist — a missing glab/gh would silently read "no_pipeline"
+# and pass the gate with no CI run at all.
+if [ "$platform" = "gitlab" ] && ! command -v glab >/dev/null 2>&1; then
+  env_fail "glab CLI not found on PATH"
+fi
+if [ "$platform" = "github" ] && ! command -v gh >/dev/null 2>&1; then
+  env_fail "gh CLI not found on PATH"
+fi
 
 # ------------------------------------------------------------------- helpers
 
@@ -135,7 +149,7 @@ else: print("in_progress")' 2>/dev/null \
 # 1. Push the story branch (propagate the current code — including any
 #    _fix_phase repair commits — so the remote CI runs on what we will check).
 if ! git -C "$worktree" push -u origin "$branch" >/dev/null 2>&1; then
-  fail "git push of $branch failed"
+  env_fail "git push of $branch failed (auth/network/remote state)"
 fi
 log "pushed $branch"
 

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
@@ -11,10 +11,15 @@
 # not push, so the branch must be re-pushed before each CI check or the fix never
 # reaches the remote pipeline.
 #
-# Exit 0 on green, or when no pipeline exists (CI not triggered / not
-# configured). Exit non-zero on red/timeout -> bmad-loop treats it as a failed
-# verify command and answers with a feedback-driven repair session (re-runs
-# bmad-build-auto with the failing output) — the auto-fix loop.
+# Exit contract (bmad-loop verify.py): a non-zero rc is a failed verify command.
+#   - rc=1  -> fixable: a RED/timed-out CI. bmad-loop re-runs bmad-build-auto
+#             with the failing output as feedback (_fix_phase, bounded by
+#             max_dev_attempts).
+#   - rc=126 -> ENV FAULT (bmad-loop ENV_FAULT_RCS={126,127}): a configuration /
+#             environment error (platform unknown, host/project unresolved,
+#             CLI/auth/network/push failure). bmad-loop ESCALATES — the run
+#             pauses for an environment fix and the story's repair budget resets
+#             — instead of burning the budget on a futile repair.
 #
 # Setup (see /bmad-issue-tracking-setup step 3c):
 #   cp <assets>/bmad-loop/ci-gate/ci-wait.sh .bmad-loop/ci-wait.sh
@@ -36,11 +41,11 @@ project="${BMAD_LOOP_SETTING_PROJECT:-}"
 timeout_sec="${BMAD_LOOP_SETTING_TIMEOUT_SEC:-1500}"
 
 log() { echo "[ci-wait] $*"; }
-# The gate itself: red/timeout CI. bmad-loop classifies rc=1 as fixable -> _fix_phase.
+# The gate itself: red/timeout CI. rc=1 is bmad-loop's fixable class -> _fix_phase.
 fail() { echo "[ci-wait] FAIL: $*"; exit 1; }
-# Configuration/environment errors (not the story's fault): rc=126 is bmad-loop's
-# env-fault class -> the run ESCALATES (pauses for an environment fix, budget
-# resets) instead of burning the story's repair budget on a futile repair.
+# Configuration/environment errors: rc=126 is bmad-loop's env-fault class -> the
+# run ESCALATES (pauses for an environment fix, budget resets) instead of burning
+# the story's repair budget on a futile repair.
 env_fail() { echo "[ci-wait] ENV-FAULT: $*"; exit 126; }
 
 # ------------------------------------------------------------------ settings
@@ -51,10 +56,13 @@ env_fail() { echo "[ci-wait] ENV-FAULT: $*"; exit 126; }
 # (opensource.unicc.org, GHE, ...) don't betray their platform in the hostname,
 # but the module records it as `git_platform` (or `platform`) in
 # `_bmad/custom/issue-tracking.yaml`, which bmad-loop copies into each worktree.
+# Strip inline YAML comments (`key: value  # comment`) so the value stays clean.
 cfg="$worktree/_bmad/custom/issue-tracking.yaml"
 if [ -z "$platform" ] && [ -f "$cfg" ]; then
-  platform="$(sed -n 's/^\s*git_platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
-  [ -z "$platform" ] && platform="$(sed -n 's/^\s*platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
+  platform="$(sed -n 's/^[[:space:]]*git_platform:[[:space:]]*//p' "$cfg" | head -1 \
+    | sed 's/[[:space:]]*#.*$//' | tr -d '"'"'"'[:space:]')"
+  [ -z "$platform" ] && platform="$(sed -n 's/^[[:space:]]*platform:[[:space:]]*//p' "$cfg" | head -1 \
+    | sed 's/[[:space:]]*#.*$//' | tr -d '"'"'"'[:space:]')"
 fi
 
 # Resolve host/project/platform from the git remote when not configured.
@@ -101,45 +109,67 @@ fi
 
 # ------------------------------------------------------------------- helpers
 
-# Latest pipeline status for the branch, or "no_pipeline".
+# Run a status function, store its output in $STATUS, and translate an
+# `env_fault:` marker into an env_fail. Must be called WITHOUT command
+# substitution: a bare `exit 126` inside `$(...)` would only exit the subshell
+# and be lost, so the functions emit `env_fault:<reason>` and this wrapper does
+# the env_fail in the caller's (main) shell.
+status_get() {
+  STATUS="$("$1")"
+  case "$STATUS" in
+    env_fault:*) env_fail "${STATUS#env_fault:}" ;;
+  esac
+}
+
+# Latest pipeline status for the branch: success/failed/running/... or
+# "no_pipeline". Emits "env_fault:<reason>" on an API/CLI error.
 branch_status() {
+  local raw rc
   case "$platform" in
     gitlab)
-      glab api "projects/${project}/pipelines?ref=${branch}" --hostname "$host" 2>/dev/null \
-        | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
-        || echo no_pipeline
+      raw="$(glab api "projects/${project}/pipelines?ref=${branch}" --hostname "$host" 2>&1)"; rc=$?
+      [ "$rc" -eq 0 ] || { echo "env_fault:glab API call failed for $host/$project — not authenticated or project not found: $(printf '%s' "$raw" | head -c 120)"; return; }
+      printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
+        || { echo "env_fault:uv run python failed — is uv installed on PATH?"; return; }
       ;;
     github)
-      gh run list --branch "$branch" -R "${host}/${project}" --limit 1 --json status,conclusion 2>/dev/null \
-        | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["conclusion"] or d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
-        || echo no_pipeline
+      raw="$(gh run list --branch "$branch" -R "${host}/${project}" --limit 1 --json status,conclusion 2>&1)"; rc=$?
+      [ "$rc" -eq 0 ] || { echo "env_fault:gh API call failed for $host/$project — not authenticated or repo not found: $(printf '%s' "$raw" | head -c 120)"; return; }
+      printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["conclusion"] or d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
+        || { echo "env_fault:uv run python failed — is uv installed on PATH?"; return; }
       ;;
   esac
 }
 
-# Pipeline status of the story's trace MR/PR (created by story-track), or
-# "no_mr"/"no_pipeline". Aggregates ALL check states on GitHub.
+# Pipeline status of the story's trace MR/PR, or "no_mr"/"no_pipeline".
+# Aggregates ALL check states on GitHub. Emits "env_fault:" on an API error.
 mr_status() {
+  local raw rc
   case "$platform" in
     gitlab)
-      iid="$(glab api "projects/${project}/merge_requests?source_branch=${branch}" --hostname "$host" 2>/dev/null \
-        | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["iid"] if d else "")' 2>/dev/null || echo "")"
+      raw="$(glab api "projects/${project}/merge_requests?source_branch=${branch}" --hostname "$host" 2>&1)"; rc=$?
+      [ "$rc" -eq 0 ] || { echo "env_fault:glab API call failed for $host/$project: $(printf '%s' "$raw" | head -c 120)"; return; }
+      iid="$(printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["iid"] if d else "")' 2>/dev/null || echo "")"
       [ -n "$iid" ] || { echo no_mr; return; }
-      glab api "projects/${project}/merge_requests/${iid}/pipelines" --hostname "$host" 2>/dev/null \
-        | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
-        || echo no_pipeline
+      raw="$(glab api "projects/${project}/merge_requests/${iid}/pipelines" --hostname "$host" 2>&1)"; rc=$?
+      [ "$rc" -eq 0 ] || { echo "env_fault:glab API call failed for $host/$project: $(printf '%s' "$raw" | head -c 120)"; return; }
+      printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
+        || { echo "env_fault:uv run python failed — is uv installed on PATH?"; return; }
       ;;
     github)
-      num="$(gh pr list --head "$branch" -R "${host}/${project}" --json number --jq '.[0].number' 2>/dev/null || echo "")"
+      raw="$(gh pr list --head "$branch" -R "${host}/${project}" --json number --jq '.[0].number' 2>&1)"; rc=$?
+      [ "$rc" -eq 0 ] || { echo "env_fault:gh API call failed for $host/$project: $(printf '%s' "$raw" | head -c 120)"; return; }
+      num="$raw"
       [ -n "$num" ] || { echo no_mr; return; }
-      gh pr checks "$num" -R "${host}/${project}" --json state 2>/dev/null \
-        | uv run --no-project python -c 'import json,sys
+      raw="$(gh pr checks "$num" -R "${host}/${project}" --json state 2>&1)"; rc=$?
+      [ "$rc" -eq 0 ] || { echo "env_fault:gh API call failed for $host/$project: $(printf '%s' "$raw" | head -c 120)"; return; }
+      printf '%s' "$raw" | uv run --no-project python -c 'import json,sys
 states=[c["state"] for c in json.load(sys.stdin)]
 if not states: print("no_pipeline")
 elif any(s in ("FAILURE","ERROR","ACTION_REQUIRED","CANCELLED","TIMED_OUT") for s in states): print("failed")
 elif all(s=="SUCCESS" for s in states): print("success")
 else: print("in_progress")' 2>/dev/null \
-        || echo no_pipeline
+        || { echo "env_fault:uv run python failed — is uv installed on PATH?"; return; }
       ;;
   esac
 }
@@ -148,43 +178,56 @@ else: print("in_progress")' 2>/dev/null \
 
 # 1. Push the story branch (propagate the current code — including any
 #    _fix_phase repair commits — so the remote CI runs on what we will check).
+#    One retry for transient network failures before escalating.
 if ! git -C "$worktree" push -u origin "$branch" >/dev/null 2>&1; then
-  env_fail "git push of $branch failed (auth/network/remote state)"
+  sleep 3
+  git -C "$worktree" push -u origin "$branch" >/dev/null 2>&1 \
+    || env_fail "git push of $branch failed (auth/network/remote state)"
 fi
 log "pushed $branch"
 
-# 2. Which pipeline to poll: the branch's if it has one, else the trace MR's.
-bs="$(branch_status)"
-mode="branch"; s="$bs"
+# 2. GitLab creates the ref pipeline asynchronously — wait a few seconds and
+#    re-check before concluding there is no pipeline (avoids a spurious
+#    post-push "no CI gate" pass on un-CI'd code).
+status_get branch_status
+for _ in 1 2 3; do
+  [ "$STATUS" = "no_pipeline" ] || break
+  sleep 5
+  status_get branch_status
+done
+
+mode="branch"; s="$STATUS"
 if [ "$s" = "no_pipeline" ] || [ -z "$s" ]; then
-  ms="$(mr_status)"
-  if [ "$ms" = "no_mr" ] || [ "$ms" = "no_pipeline" ] || [ -z "$ms" ]; then
+  status_get mr_status
+  if [ "$STATUS" = "no_mr" ] || [ "$STATUS" = "no_pipeline" ] || [ -z "$STATUS" ]; then
     log "no pipeline found for $branch — no CI gate"
     exit 0
   fi
-  mode="mr"; s="$ms"
+  mode="mr"; s="$STATUS"
 fi
 log "polling $mode pipeline for $branch (timeout ${timeout_sec}s)"
 
-# 2. Poll until green/red/timeout.
+# 3. Poll until green/red/timeout.
 deadline=$(( $(date +%s) + timeout_sec ))
 while :; do
   [ "$(date +%s)" -ge "$deadline" ] && fail "CI timeout after ${timeout_sec}s"
   if [ "$mode" = "mr" ]; then
-    s="$(mr_status)"
+    status_get mr_status
+    s="$STATUS"
     if [ "$s" = "no_pipeline" ]; then
       # MR pipeline not indexed yet but a branch pipeline exists — fall back.
-      bs2="$(branch_status)"
-      [ "$bs2" = "no_pipeline" ] || { mode="branch"; s="$bs2"; }
+      status_get branch_status
+      [ "$STATUS" = "no_pipeline" ] || { mode="branch"; s="$STATUS"; }
     fi
   else
-    s="$(branch_status)"
+    status_get branch_status
+    s="$STATUS"
   fi
   case "$s" in
     success|SUCCESS|completed|successful) log "CI green"; exit 0 ;;
     failed|FAILURE|failure|error|ERROR|cancelled|canceled|skipped|manual|neutral|stale|timed_out|action_required)
       fail "CI failed ($s)" ;;
-    no_mr) fail "no MR available for CI" ;;
+    no_mr) env_fail "no MR available for CI (the story-track trace MR is gone — a remote-state issue, not the story's code)" ;;
     running|pending|queued|in_progress|no_pipeline|""|null) sleep 30 ;;
     *) sleep 30 ;;
   esac

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -26,10 +26,12 @@ Do this after the push + MR. If any step here fails, **report it and continue â€
 do not fail the session over tracking**. The post-run `/bmad-bmm-issue-sync`
 reconciles the full board.
 
-1. Read `_bmad/custom/issue-tracking.yaml` for `platform`, `host`, `project`
-   (issue tracker). Read `prd_key` from the PRD frontmatter: find `prd.md` under
-   the planning artifacts (path from `_bmad/bmm/config.yaml` `planning_artifacts`,
-   or search the repo for `prd.md`) and read its `prd_key` frontmatter.
+1. Read `_bmad/custom/issue-tracking.yaml` for `git_platform` (git remote
+   platform â€” `gitlab` or `github`; self-hosted GitLab instances have a custom
+   host but `git_platform: gitlab`), `host`, `project`. Read `prd_key` from the
+   PRD frontmatter: find `prd.md` under the planning artifacts (path from
+   `_bmad/bmm/config.yaml` `planning_artifacts`, or search the repo for
+   `prd.md`) and read its `prd_key` frontmatter.
 
 2. Find the story's issue by its sprint key `{story_key}`, scoped by the prd label:
    - GitLab: `glab api "projects/{project}/issues?search={story_key}&labels=prd::{prd_key}" --hostname {host}`

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -20,10 +20,18 @@ These must succeed — the subsequent CI check depends on them.
      the PRD branch (story → PRD), matching the module's branch model. If
      `branch_patterns.prd` is absent, fall back to `git symbolic-ref
      refs/remotes/origin/HEAD`.
+   - **MR title follows the module's convention** `Story {epic}.{story}: {title}`
+     (the same title the module uses for the story's issue — see
+     `_bmad/_config/custom/bmad-workflow-lang.md` / CLAUDE.md "Issue title
+     formats"). Derive it: `{epic}.{story}` from the story key (the leading
+     `{epic}-{story}` of the branch slug, e.g. `2-1-...` → `Story 2.1:`), and
+     `{title}` from the story spec's `# Story {e}.{n}: <title>` heading (search
+     for the story file under the implementation artifacts whose name starts
+     with the story key); fall back to the branch slug title-cased.
    - GitLab: if `glab api "projects/{project}/merge_requests?source_branch={branch}"` is empty, create
-     `glab mr create --source-branch {branch} --target-branch {target} --title "CI: {branch}" --description "Trace MR created by bmad-loop story-track." --yes --no-editor -R "{host}/{project}"`.
+     `glab mr create --source-branch {branch} --target-branch {target} --title "{title}" --description "Trace MR created by bmad-loop story-track." --yes --no-editor -R "{host}/{project}"`.
    - GitHub: if `gh pr list --head {branch} -R "{host}/{project}"` is empty, create
-     `gh pr create --base {target} --head {branch} --title "CI: {branch}" --body "Trace PR created by bmad-loop story-track." -R "{host}/{project}"`.
+     `gh pr create --base {target} --head {branch} --title "{title}" --body "Trace PR created by bmad-loop story-track." -R "{host}/{project}"`.
 
 ## Best-effort: mirror the story to its issue
 

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -13,8 +13,13 @@ These must succeed — the subsequent CI check depends on them.
 2. **Ensure a trace MR/PR exists** for this branch (CI vehicle + execution
    trace; leave it open — GitLab auto-marks it merged after the merge-back is
    pushed to the target branch):
-   - Resolve `{host}`/`{project}` from `git remote get-url origin`, and the
-     target branch from `git symbolic-ref refs/remotes/origin/HEAD`.
+   - Resolve `{host}`/`{project}` from `git remote get-url origin`. Resolve the
+     target branch as the **PRD branch** (NOT main): read `branch_patterns.prd`
+     from `_bmad/custom/issue-tracking.yaml` (e.g. `feat/{prd_key}/prd`) and
+     substitute `prd_key` (read from `prd.md` frontmatter). The trace MR targets
+     the PRD branch (story → PRD), matching the module's branch model. If
+     `branch_patterns.prd` is absent, fall back to `git symbolic-ref
+     refs/remotes/origin/HEAD`.
    - GitLab: if `glab api "projects/{project}/merge_requests?source_branch={branch}"` is empty, create
      `glab mr create --source-branch {branch} --target-branch {target} --title "CI: {branch}" --description "Trace MR created by bmad-loop story-track." --yes --no-editor -R "{host}/{project}"`.
    - GitHub: if `gh pr list --head {branch} -R "{host}/{project}"` is empty, create


### PR DESCRIPTION
Live-test follow-up: config/env failures in ci-wait.sh now exit 126 (bmad-loop env-fault class -> escalate, budget resets) instead of 1 (fixable -> futile _fix_phase repairs -> defer).