### PR TITLE
feat(story-track): one trace MR per story — re-point re-driven MR, delete old remote branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ci-wait.sh` (bmad-loop CI gate): configuration/environment errors now exit **126** (bmad-loop's env-fault class → the run escalates/pauses, budget resets) instead of 1 (fixable → futile repair burn → story defer). A red/timeout CI still exits 1 → `_fix_phase`.
 - `ci-wait.sh`: platform resolved from `_bmad/custom/issue-tracking.yaml` (`git_platform`) so self-hosted GitLab/GitHub instances work; inline YAML comments stripped; glab/gh API or auth failures escalate instead of silently passing as "no pipeline".
-- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`, and its title follows the module's convention `Story {epic}.{story}: {title}` instead of `CI: {branch}`.
+- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`, its title follows the module's convention `Story {epic}.{story}: {title}` instead of `CI: {branch}`, and a re-driven story's trace MR is **re-pointed to the new branch** (GitLab) with the old remote branch deleted — one active trace MR per story, keeping the MR's history.
 
 ## [2.3.0] - 2026-08-11
 

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -33,6 +33,18 @@ These must succeed — the subsequent CI check depends on them.
    - GitHub: if `gh pr list --head {branch} -R "{host}/{project}"` is empty, create
      `gh pr create --base {target} --head {branch} --title "{title}" --body "Trace PR created by bmad-loop story-track." -R "{host}/{project}"`.
 
+3. **One trace MR per story** (a re-driven story — e.g. after a defer — leaves a stale MR from an earlier run on another branch; re-point it instead of stacking duplicates):
+   - Find open MRs/PRs referencing this story (search by title `{title}` or key `{story_key}`):
+     - GitLab: `glab api "projects/{project}/merge_requests?state=opened&search={title}"`.
+     - GitHub: `gh pr list --state open --search "in:title {title}" -R "{host}/{project}"`.
+   - If an MR/PR exists whose source branch is NOT the current branch:
+     - **GitLab — re-point it** via the API (keeps the MR's history/comments; its diff becomes the re-driven story's):
+       `glab api --method PUT "projects/{project}/merge_requests/{iid}" --hostname {host} -F source_branch={current_branch}`.
+       Then **delete the old remote branch**: `git push origin --delete <old_source_branch>` — bmad-loop keeps it locally (keep_failed), so only the remote ref is removed.
+     - **GitHub — no re-point support**: close the old PR (`gh pr close {num}`) and create a new one on the current branch (title `{title}`).
+   - If no MR/PR exists, create one on the current branch (step 2 above).
+   This is best-effort — if it fails, report and continue.
+
 ## Best-effort: mirror the story to its issue
 
 Do this after the push + MR. If any step here fails, **report it and continue —


### PR DESCRIPTION
A re-driven story (e.g. after a defer) leaves a stale trace MR on an earlier run's branch (and duplicate remote branches). story-track now:
- finds open MRs/PRs referencing the story (search by title/key)
- GitLab: re-points the MR on another branch to the current one via the API (glab mr update lacks --source-branch), deletes the old remote branch (git push origin --delete) — bmad-loop keeps it locally (keep_failed)
- GitHub (no re-point support): closes the old PR and creates a new one
One active trace MR per story.