### PR TITLE
fix: URL-encode GitLab project path for nested-group namespaces (live-test blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- `ci-wait.sh` (bmad-loop CI gate): configuration/environment errors now exit **126** (bmad-loop's env-fault class → the run escalates/pauses, budget resets) instead of 1 (fixable → futile repair burn → story defer). A red/timeout CI still exits 1 → `_fix_phase`.
-- `ci-wait.sh`: platform resolved from `_bmad/custom/issue-tracking.yaml` (`git_platform`) so self-hosted GitLab/GitHub instances work; inline YAML comments stripped; glab/gh API or auth failures escalate instead of silently passing as "no pipeline".
-- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`, its title follows the module's convention `Story {epic}.{story}: {title}` instead of `CI: {branch}`, and a re-driven story's trace MR is **re-pointed to the new branch** (GitLab) with the old remote branch deleted — one active trace MR per story, keeping the MR's history.
-- **GitLab nested-group namespaces fixed**: the GitLab API requires the URL-encoded project path (`projects/un%2Fitu%2Fgenie-ai`, not `projects/un/itu/genie-ai`). `common/check-config.yaml` now computes `project_enc` and all `glab api "projects/..."` calls (issue sync, find/create/update issues, labels, board, code-review/dev-story comments, `ci-wait.sh`, `story-track`) use it — projects under group/subgroup namespaces work.
-
-## [2.3.0] - 2026-08-11
-
-[compare v2.2.0...v2.3.0](https://github.com/jrevillard/bmad-issue-tracking/compare/v2.2.0...v2.3.0)
-
 ### Changed
 
 - **Requires BMM 6.11.0+** (was 6.4.0+): targets the 6.11.0 skill set — `bmad-ux`, consolidated `bmad-sprint-planning`, `uv`-based tooling. Version gate in setup updated.
@@ -40,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GitLab nested-group namespaces fixed**: the GitLab API requires the URL-encoded project path (`projects/un%2Fitu%2Fgenie-ai`, not `projects/un/itu/genie-ai`). `common/check-config.yaml` now computes `project_enc` and all `glab api "projects/..."` calls (issue sync, find/create/update issues, labels, board, code-review/dev-story comments, `ci-wait.sh`, `story-track`) use it — projects under group/subgroup namespaces work.
+- `ci-wait.sh` (bmad-loop CI gate): configuration/environment errors now exit **126** (bmad-loop's env-fault class → the run escalates/pauses, budget resets) instead of 1 (fixable → futile repair burn → story defer). A red/timeout CI still exits 1 → `_fix_phase`.
+- `ci-wait.sh`: platform resolved from `_bmad/custom/issue-tracking.yaml` (`git_platform`) so self-hosted GitLab/GitHub instances work; inline YAML comments stripped; glab/gh API or auth failures escalate instead of silently passing as "no pipeline".
+- `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`, its title follows the module's convention `Story {epic}.{story}: {title}` instead of `CI: {branch}`, and a re-driven story's trace MR is **re-pointed to the new branch** (GitLab) with the old remote branch deleted — one active trace MR per story, keeping the MR's history.
 - `ensure-board.yaml`: added missing `--paginate` to `glab api projects/{project}/labels` — projects with >20 labels would miss status labels beyond the first page, causing board columns to not be created
 - `find-issue.yaml`: added missing `--paginate` to GitHub `gh api search/issues` — could miss issue matches beyond the first 100 results
 - `sync-issues.yaml`: four `uv run python` blocks referenced `sys.argv` without `import sys` (NameError at runtime) — added the missing imports
@@ -226,7 +219,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `bmad-bmm-issue-link` skill (obsolete, sync task handles MR creation)
 - Known issue workaround for git branch naming conflict (fixed by PRD pattern change)
 
-[2.3.0]: https://github.com/jrevillard/bmad-issue-tracking/compare/v2.2.0...v2.3.0
 [1.3.0]: https://github.com/jrevillard/bmad-issue-tracking/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/jrevillard/bmad-issue-tracking/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/jrevillard/bmad-issue-tracking/compare/v1.1.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ci-wait.sh` (bmad-loop CI gate): configuration/environment errors now exit **126** (bmad-loop's env-fault class → the run escalates/pauses, budget resets) instead of 1 (fixable → futile repair burn → story defer). A red/timeout CI still exits 1 → `_fix_phase`.
 - `ci-wait.sh`: platform resolved from `_bmad/custom/issue-tracking.yaml` (`git_platform`) so self-hosted GitLab/GitHub instances work; inline YAML comments stripped; glab/gh API or auth failures escalate instead of silently passing as "no pipeline".
 - `story-track`: the trace MR now targets the **PRD branch** (`branch_patterns.prd`) instead of `main`, its title follows the module's convention `Story {epic}.{story}: {title}` instead of `CI: {branch}`, and a re-driven story's trace MR is **re-pointed to the new branch** (GitLab) with the old remote branch deleted — one active trace MR per story, keeping the MR's history.
+- **GitLab nested-group namespaces fixed**: the GitLab API requires the URL-encoded project path (`projects/un%2Fitu%2Fgenie-ai`, not `projects/un/itu/genie-ai`). `common/check-config.yaml` now computes `project_enc` and all `glab api "projects/..."` calls (issue sync, find/create/update issues, labels, board, code-review/dev-story comments, `ci-wait.sh`, `story-track`) use it — projects under group/subgroup namespaces work.
 
 ## [2.3.0] - 2026-08-11
 

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/ci-gate/ci-wait.sh
@@ -65,16 +65,6 @@ if [ -z "$platform" ] && [ -f "$cfg" ]; then
     | sed 's/[[:space:]]*#.*$//' | tr -d '"'"'"'[:space:]')"
 fi
 
-# Resolve platform from the module config first — self-hosted instances
-# (opensource.unicc.org, GHE, ...) don't betray their platform in the hostname,
-# but the module records it as `git_platform` (or `platform`) in
-# `_bmad/custom/issue-tracking.yaml`, which bmad-loop copies into each worktree.
-cfg="$worktree/_bmad/custom/issue-tracking.yaml"
-if [ -z "$platform" ] && [ -f "$cfg" ]; then
-  platform="$(sed -n 's/^\s*git_platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
-  [ -z "$platform" ] && platform="$(sed -n 's/^\s*platform:\s*//p' "$cfg" | head -1 | tr -d '"'"'"'[:space:]')"
-fi
-
 # Resolve host/project/platform from the git remote when not configured.
 if [ -z "$host" ] || [ -z "$project" ] || [ -z "$platform" ]; then
   remote="$(git -C "$worktree" remote get-url origin 2>/dev/null || true)"
@@ -108,6 +98,10 @@ fi
 [ -n "$project" ] || env_fail "could not resolve project from remote"
 [ -n "$platform" ] || env_fail "platform not resolved (gitlab | github)"
 
+# The GitLab API requires the URL-encoded namespace path for nested groups
+# (`projects/un%2Fitu%2Fgenie-ai`, not `projects/un/itu/genie-ai`).
+project_enc="${project//\//%2F}"
+
 # The CI CLI must exist — a missing glab/gh would silently read "no_pipeline"
 # and pass the gate with no CI run at all.
 if [ "$platform" = "gitlab" ] && ! command -v glab >/dev/null 2>&1; then
@@ -137,7 +131,7 @@ branch_status() {
   local raw rc
   case "$platform" in
     gitlab)
-      raw="$(glab api "projects/${project}/pipelines?ref=${branch}" --hostname "$host" 2>&1)"; rc=$?
+      raw="$(glab api "projects/${project_enc}/pipelines?ref=${branch}" --hostname "$host" 2>&1)"; rc=$?
       [ "$rc" -eq 0 ] || { echo "env_fault:glab API call failed for $host/$project — not authenticated or project not found: $(printf '%s' "$raw" | head -c 120)"; return; }
       printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
         || { echo "env_fault:uv run python failed — is uv installed on PATH?"; return; }
@@ -157,11 +151,11 @@ mr_status() {
   local raw rc
   case "$platform" in
     gitlab)
-      raw="$(glab api "projects/${project}/merge_requests?source_branch=${branch}" --hostname "$host" 2>&1)"; rc=$?
+      raw="$(glab api "projects/${project_enc}/merge_requests?source_branch=${branch}" --hostname "$host" 2>&1)"; rc=$?
       [ "$rc" -eq 0 ] || { echo "env_fault:glab API call failed for $host/$project: $(printf '%s' "$raw" | head -c 120)"; return; }
       iid="$(printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["iid"] if d else "")' 2>/dev/null || echo "")"
       [ -n "$iid" ] || { echo no_mr; return; }
-      raw="$(glab api "projects/${project}/merge_requests/${iid}/pipelines" --hostname "$host" 2>&1)"; rc=$?
+      raw="$(glab api "projects/${project_enc}/merge_requests/${iid}/pipelines" --hostname "$host" 2>&1)"; rc=$?
       [ "$rc" -eq 0 ] || { echo "env_fault:glab API call failed for $host/$project: $(printf '%s' "$raw" | head -c 120)"; return; }
       printf '%s' "$raw" | uv run --no-project python -c 'import json,sys; d=json.load(sys.stdin); print(d[0]["status"] if d else "no_pipeline")' 2>/dev/null \
         || { echo "env_fault:uv run python failed — is uv installed on PATH?"; return; }

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -13,7 +13,10 @@ These must succeed — the subsequent CI check depends on them.
 2. **Ensure a trace MR/PR exists** for this branch (CI vehicle + execution
    trace; leave it open — GitLab auto-marks it merged after the merge-back is
    pushed to the target branch):
-   - Resolve `{host}`/`{project}` from `git remote get-url origin`. Resolve the
+   - Resolve `{host}`/`{project}` from `git remote get-url origin`. For every
+     `glab api "projects/..."` call, **URL-encode the project path** (nested
+     groups need it): `projects/{project}` → `projects/{project//\//%2F}` (e.g.
+     `un/itu/genie-ai` → `un%2Fitu%2Fgenie-ai`). Resolve the
      target branch as the **PRD branch** (NOT main): read `branch_patterns.prd`
      from `_bmad/custom/issue-tracking.yaml` (e.g. `feat/{prd_key}/prd`) and
      substitute `prd_key` (read from `prd.md` frontmatter). The trace MR targets

--- a/skills/bmad-issue-tracking-setup/assets/workflows/code-review/complete.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/code-review/complete.yaml
@@ -61,7 +61,7 @@ else:
         - WRITE:
             file: /tmp/review-findings.md
             content: "{review_section}"
-        - RUN: glab api --method POST "projects/{project}/issues/{issue_id}/notes" --hostname {host} -F "body=@/tmp/review-findings.md"
+        - RUN: glab api --method POST "projects/{project_enc}/issues/{issue_id}/notes" --hostname {host} -F "body=@/tmp/review-findings.md"
           PLATFORM: gitlab
           EXPECT_EXIT: 0
         - RUN: gh issue comment {issue_id} --body-file "/tmp/review-findings.md" -R "{host}/{project}"

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/check-config.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/check-config.yaml
@@ -45,3 +45,15 @@
     - OUTPUT:
         message: "worktree_base not configured. Run /bmad-issue-tracking-setup (step 4) to configure."
         stop: true
+- CHECK: exists project
+  FALSE:
+    - OUTPUT:
+        message: "project not configured. Run /bmad-issue-tracking-setup (step 5) to configure."
+        stop: true
+# GitLab API requires the URL-encoded namespace path for nested groups
+# (`projects/un%2Fitu%2Fgenie-ai`, not `projects/un/itu/genie-ai`).
+- RUN: uv run --no-project python -c "
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=''))
+" {project}
+  STORE: project_enc

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/create-issue.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/create-issue.yaml
@@ -12,7 +12,7 @@
 # Requires: host and project in scope (provided by common/check-config via callers)
 
 # Search for existing issue
-- RUN: glab api --paginate "projects/{project}/issues?search={title}&labels=prd{sep}{prd_key}" --hostname {host}
+- RUN: glab api --paginate "projects/{project_enc}/issues?search={title}&labels=prd{sep}{prd_key}" --hostname {host}
   STORE: search_result
   PLATFORM: gitlab
 - RUN: gh api "repos/{project}/issues?state=all&per_page=100&labels=prd{sep}{prd_key}" --hostname {host} --paginate
@@ -60,7 +60,7 @@ labels = sys.argv[1].strip().split('\n')
 print(','.join(labels))
 " "{labels}"
   STORE: label_arg
-- RUN: glab api --method POST "projects/{project}/issues" --hostname {host} -f "title={title}" -F "description=@{description_file}" -f "labels={label_arg}"
+- RUN: glab api --method POST "projects/{project_enc}/issues" --hostname {host} -f "title={title}" -F "description=@{description_file}" -f "labels={label_arg}"
   STORE: create_result
   PLATFORM: gitlab
 - RUN: gh issue create --title "{title}" --body-file "{description_file}" --label "{label_arg}" -R "{host}/{project}"

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/ensure-board.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/ensure-board.yaml
@@ -11,7 +11,7 @@
     - STOP
 
 # Check if BMAD Sprint Board already exists
-- RUN: glab api "projects/{project}/boards" --hostname {host} | uv run --no-project python -c "
+- RUN: glab api "projects/{project_enc}/boards" --hostname {host} | uv run --no-project python -c "
 import json, sys
 boards = json.load(sys.stdin)
 print(next((b['id'] for b in boards if b['name'] == 'BMAD Sprint Board'), ''))
@@ -20,12 +20,12 @@ print(next((b['id'] for b in boards if b['name'] == 'BMAD Sprint Board'), ''))
   PLATFORM: gitlab
 - CHECK: empty board_id
   TRUE:
-    - RUN: glab api --method POST "projects/{project}/boards" --hostname {host} -f "name=BMAD Sprint Board" | uv run --no-project python -c "import json,sys; print(json.load(sys.stdin)['id'])"
+    - RUN: glab api --method POST "projects/{project_enc}/boards" --hostname {host} -f "name=BMAD Sprint Board" | uv run --no-project python -c "import json,sys; print(json.load(sys.stdin)['id'])"
       STORE: board_id
       PLATFORM: gitlab
 
 # Add columns for active status labels (omit done/closed/deferred/optional)
-- RUN: glab api "projects/{project}/labels" --hostname {host} --paginate | uv run --no-project python -c "
+- RUN: glab api "projects/{project_enc}/labels" --hostname {host} --paginate | uv run --no-project python -c "
 import json, sys, re
 pages = sys.stdin.read().strip().split('\n')
 labels = []
@@ -42,5 +42,5 @@ for l in labels:
     items: status_label_ids
     as: label_id
     do:
-      - RUN: glab api --method POST "projects/{project}/boards/{board_id}/lists" --hostname {host} -f "label_id={label_id}" 2>/dev/null || true
+      - RUN: glab api --method POST "projects/{project_enc}/boards/{board_id}/lists" --hostname {host} -f "label_id={label_id}" 2>/dev/null || true
         PLATFORM: gitlab

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/find-issue.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/find-issue.yaml
@@ -9,7 +9,7 @@
 #   - issue_id: the issue IID (GitLab) or number (GitHub); empty string if not found
 # Side effects: none
 
-- RUN: glab api "projects/{project}/issues?search={search_text}&labels=prd{sep}{prd_key}" --hostname {host} --paginate
+- RUN: glab api "projects/{project_enc}/issues?search={search_text}&labels=prd{sep}{prd_key}" --hostname {host} --paginate
   STORE: issue_result
   PLATFORM: gitlab
 - RUN: gh api "search/issues?q={search_text}+repo:{project}+label:prd{sep}{prd_key}&per_page=100" --hostname {host} --paginate | uv run --no-project python -c "import json,sys; pages=sys.stdin.read().strip().split('\n'); items=[]; [items.extend(json.loads(p).get('items',[])) for p in pages if p]; print(json.dumps(items))"

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/sync-issues.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/sync-issues.yaml
@@ -16,7 +16,7 @@
 - SET: { variable: sync_updated, value: "0" }
 - SET: { variable: sync_skipped, value: "0" }
 # Fetch all PRD issues (bulk fetch for matching)
-- RUN: glab api "projects/{project}/issues?labels=prd{sep}{prd_key}&state=all&per_page=100" --hostname {host} --paginate | uv run --no-project python -c "
+- RUN: glab api "projects/{project_enc}/issues?labels=prd{sep}{prd_key}&state=all&per_page=100" --hostname {host} --paginate | uv run --no-project python -c "
 import json, sys
 issues = json.load(sys.stdin)
 for i in issues:
@@ -149,7 +149,7 @@ else:
           # Found — check status
           - CHECK: platform eq "gitlab"
             TRUE:
-              - RUN: glab api "projects/{project}/issues/{issue_id}" --hostname {host} | uv run --no-project python -c "
+              - RUN: glab api "projects/{project_enc}/issues/{issue_id}" --hostname {host} | uv run --no-project python -c "
 import json, sys
 for l in json.load(sys.stdin)['labels']:
     if l.startswith('status'):

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/update-issue-description.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/update-issue-description.yaml
@@ -7,7 +7,7 @@
 # Output variables: (none)
 # Side effects: updates issue description on the issue tracker
 
-- RUN: glab api --method PUT "projects/{project}/issues/{issue_id}" --hostname {host} -F "description=@{description_file}"
+- RUN: glab api --method PUT "projects/{project_enc}/issues/{issue_id}" --hostname {host} -F "description=@{description_file}"
   PLATFORM: gitlab
   EXPECT_EXIT: 0
 - RUN: gh issue edit {issue_id} --body-file "{description_file}" -R "{host}/{project}"

--- a/skills/bmad-issue-tracking-setup/assets/workflows/common/update-issue-status.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/common/update-issue-status.yaml
@@ -9,7 +9,7 @@
 # Side effects: updates issue labels and state on the issue tracker
 
 # GitLab: fetch current labels, filter out old status::*, append new, send full set
-- RUN: glab api "projects/{project}/issues/{issue_id}" --hostname {host} --paginate
+- RUN: glab api "projects/{project_enc}/issues/{issue_id}" --hostname {host} --paginate
   STORE: issue_detail
   PLATFORM: gitlab
 - RUN: uv run --no-project python -c "
@@ -21,7 +21,7 @@ print(','.join(labels))
 " {new_status}
   STORE: gitlab_labels
   PLATFORM: gitlab
-- RUN: glab api --method PUT "projects/{project}/issues/{issue_id}" --hostname {host} -F "labels={gitlab_labels}"
+- RUN: glab api --method PUT "projects/{project_enc}/issues/{issue_id}" --hostname {host} -F "labels={gitlab_labels}"
   PLATFORM: gitlab
   EXPECT_EXIT: 0
 # GitHub: fetch old status label, remove it, add new one
@@ -39,7 +39,7 @@ print(','.join(labels))
 # State change: close, reopen, or skip
 - CHECK: close eq "true"
   TRUE:
-    - RUN: glab api --method PUT "projects/{project}/issues/{issue_id}" --hostname {host} -F "state_event=close"
+    - RUN: glab api --method PUT "projects/{project_enc}/issues/{issue_id}" --hostname {host} -F "state_event=close"
       PLATFORM: gitlab
       EXPECT_EXIT: 0
     - RUN: gh issue close {issue_id} -R "{host}/{project}"
@@ -47,7 +47,7 @@ print(','.join(labels))
       EXPECT_EXIT: 0
 - CHECK: close eq "false"
   TRUE:
-    - RUN: glab api --method PUT "projects/{project}/issues/{issue_id}" --hostname {host} -F "state_event=reopen"
+    - RUN: glab api --method PUT "projects/{project_enc}/issues/{issue_id}" --hostname {host} -F "state_event=reopen"
       PLATFORM: gitlab
       EXPECT_EXIT: 0
     - RUN: gh issue reopen {issue_id} -R "{host}/{project}"

--- a/skills/bmad-issue-tracking-setup/assets/workflows/dev-story/complete.yaml
+++ b/skills/bmad-issue-tracking-setup/assets/workflows/dev-story/complete.yaml
@@ -56,7 +56,7 @@ else:
       EXPECT_EXIT: 0
     - CHECK: empty issue_id
       FALSE:
-        - RUN: glab api --method POST "projects/{project}/issues/{issue_id}/notes" --hostname {host} -F "body=@/tmp/dev-story-comment.md"
+        - RUN: glab api --method POST "projects/{project_enc}/issues/{issue_id}/notes" --hostname {host} -F "body=@/tmp/dev-story-comment.md"
           PLATFORM: gitlab
           EXPECT_EXIT: 0
         - RUN: gh issue comment {issue_id} --body-file "/tmp/dev-story-comment.md" -R "{host}/{project}"


### PR DESCRIPTION
The GitLab API requires the URL-encoded namespace path for nested groups: projects/un%2Fitu%2Fgenie-ai works, projects/un/itu/genie-ai returns 404. This was the root cause of the bmad-loop run pausing at ci-wait (env-fault 126 on the glab API 404), leaving stories never-done and re-picked into new branches each run.

- ci-wait.sh: project_enc in the glab api pipeline/MR calls
- story-track prompt: URL-encode the project path
- common/check-config.yaml: compute project_enc + validate project
- All module workflows: projects/{project} -> projects/{project_enc} in glab api calls (find-issue, sync-issues, create-issue, update-issue-status/description, ensure-board/dynamic-labels, code-review/dev-story comments)
- Removed a duplicated config-resolution block in ci-wait.sh (merge residue)
- 731 tests pass