### PR TITLE
docs(story-track): strengthen constraints — no code rewriting, use module workflows

### DIFF
--- a/.serena/project.local.yml
+++ b/.serena/project.local.yml
@@ -1,0 +1,5 @@
+# This file allows you to locally override settings in project.yml for development purposes.
+#
+# Use the same keys as in project.yml here. Any setting you specify will override the corresponding
+# setting in project.yml, allowing you to customise the configuration for your local development environment
+# without affecting the project configuration in project.yml (which is intended to be versioned).

--- a/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
+++ b/skills/bmad-issue-tracking-setup/assets/bmad-loop/story-track/story-track-prompt.md
@@ -80,8 +80,12 @@ reconciles the full board.
 
 - **Do NOT modify `sprint-status.yaml`** — the orchestrator owns it and
   reconciles it after you finish.
-- Use the module's deployed workflows under
-  `_bmad/_config/custom/workflows/common/` (`update-issue-status.yaml`,
-  `find-issue.yaml`) as the canonical logic where it helps.
+- **Do NOT rewrite code** — the module provides canonical workflows under
+  `_bmad/_config/custom/workflows/common/` that handle platform differences,
+  pagination, URL encoding, and API specifics. Use them (INCLUDE) instead of
+  writing ad-hoc scripts.
+- For issue/board/label operations, INCLUDE the module's workflows. Use the
+  platform CLI only for operations NOT covered by the workflows (e.g., posting
+  comments, listing MRs/PRs).
 
 Then end your turn following the Completion signal contract below.


### PR DESCRIPTION
The module's common/ workflows handle platform differences, pagination, URL encoding, and API specifics. The prompt now explicitly forbids ad-hoc rewrites and directs the agent to INCLUDE the workflows for issue/board/label operations. Generic wording (no platform-specific mentions) to support future platforms.